### PR TITLE
chore(deps): Upgrade dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "merge-stream": "^2.0.0",
         "prettier": "^2.4.1",
         "standard-version": "^9.3.1",
-        "typedoc": "^0.22.7",
+        "typedoc": "^0.22.10",
         "typescript": "^4.5.2"
       },
       "engines": {
@@ -8875,9 +8875,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "node_modules/typedoc": {
-      "version": "0.22.7",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.7.tgz",
-      "integrity": "sha512-ndxxp+tU1Wczvdxp4u2/PvT1qjD6hdFdSdehpORHjE+JXmMkl2bftXCR0upHmsnesBG7VCcr8vfgloGHIH8glQ==",
+      "version": "0.22.10",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.10.tgz",
+      "integrity": "sha512-hQYZ4WtoMZ61wDC6w10kxA42+jclWngdmztNZsDvIz7BMJg7F2xnT+uYsUa7OluyKossdFj9E9Ye4QOZKTy8SA==",
       "dev": true,
       "dependencies": {
         "glob": "^7.2.0",
@@ -8893,7 +8893,7 @@
         "node": ">= 12.10.0"
       },
       "peerDependencies": {
-        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x"
+        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x"
       }
     },
     "node_modules/typescript": {
@@ -16436,9 +16436,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typedoc": {
-      "version": "0.22.7",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.7.tgz",
-      "integrity": "sha512-ndxxp+tU1Wczvdxp4u2/PvT1qjD6hdFdSdehpORHjE+JXmMkl2bftXCR0upHmsnesBG7VCcr8vfgloGHIH8glQ==",
+      "version": "0.22.10",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.10.tgz",
+      "integrity": "sha512-hQYZ4WtoMZ61wDC6w10kxA42+jclWngdmztNZsDvIz7BMJg7F2xnT+uYsUa7OluyKossdFj9E9Ye4QOZKTy8SA==",
       "dev": true,
       "requires": {
         "glob": "^7.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
       },
       "devDependencies": {
         "@commitlint/cli": "14.1",
-        "@commitlint/config-conventional": "14.1",
+        "@commitlint/config-conventional": "15.0",
         "@types/amqplib": "^0.8.2",
         "@types/body-parser": "^1.16.7",
         "@types/cors": "^2.8.3",
@@ -169,9 +169,9 @@
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-14.1.0.tgz",
-      "integrity": "sha512-JuhCqkEv8jyqmd54EpXPsQFpYc/8k7sfP1UziRdEvZSJUCLxz+8Pk4cNS0oF1BtjaWO7ITgXPlIZg47PyApGmg==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-15.0.0.tgz",
+      "integrity": "sha512-eZBRL8Lk3hMNHp1wUMYj0qrZQEsST1ai7KHR8J1IDD9aHgT7L2giciibuQ+Og7vxVhR5WtYDvh9xirXFVPaSkQ==",
       "dev": true,
       "dependencies": {
         "conventional-changelog-conventionalcommits": "^4.3.1"
@@ -9504,9 +9504,9 @@
       }
     },
     "@commitlint/config-conventional": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-14.1.0.tgz",
-      "integrity": "sha512-JuhCqkEv8jyqmd54EpXPsQFpYc/8k7sfP1UziRdEvZSJUCLxz+8Pk4cNS0oF1BtjaWO7ITgXPlIZg47PyApGmg==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-15.0.0.tgz",
+      "integrity": "sha512-eZBRL8Lk3hMNHp1wUMYj0qrZQEsST1ai7KHR8J1IDD9aHgT7L2giciibuQ+Og7vxVhR5WtYDvh9xirXFVPaSkQ==",
       "dev": true,
       "requires": {
         "conventional-changelog-conventionalcommits": "^4.3.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "reflect-metadata": "^0.1.10"
       },
       "devDependencies": {
-        "@commitlint/cli": "14.1",
+        "@commitlint/cli": "15.0",
         "@commitlint/config-conventional": "15.0",
         "@types/amqplib": "^0.8.2",
         "@types/body-parser": "^1.16.7",
@@ -146,16 +146,16 @@
       }
     },
     "node_modules/@commitlint/cli": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-14.1.0.tgz",
-      "integrity": "sha512-Orq62jkl9qAGvjFqhehtAqjGY/duJ8hIRPPIHmGR2jIB96D4VTmazS3ZvqJz2Q9kKr61mLAk/171zm0FVzQCYA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-15.0.0.tgz",
+      "integrity": "sha512-Y5xmDCweytqzo4N4lOI2YRiuX35xTjcs8n5hUceBH8eyK0YbwtgWX50BJOH2XbkwEmII9blNhlBog6AdQsqicg==",
       "dev": true,
       "dependencies": {
-        "@commitlint/format": "^14.1.0",
-        "@commitlint/lint": "^14.1.0",
-        "@commitlint/load": "^14.1.0",
-        "@commitlint/read": "^14.0.0",
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/format": "^15.0.0",
+        "@commitlint/lint": "^15.0.0",
+        "@commitlint/load": "^15.0.0",
+        "@commitlint/read": "^15.0.0",
+        "@commitlint/types": "^15.0.0",
         "lodash": "^4.17.19",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0",
@@ -181,12 +181,12 @@
       }
     },
     "node_modules/@commitlint/ensure": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-14.1.0.tgz",
-      "integrity": "sha512-xrYvFdqVepT3XA1BmSh88eKbvYKtLuQu98QLfgxVmwS99Kj3yW0sT3D7jGvNsynbIx2dhbXofDyubf/DKkpFrQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-15.0.0.tgz",
+      "integrity": "sha512-7DV4iNIald3vycwaWBNGk5FbonaNzOlU8nBe5m5AgU2dIeNKuXwLm+zzJzG27j0Ho56rgz//3F6RIvmsoxY9ZA==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/types": "^15.0.0",
         "lodash": "^4.17.19"
       },
       "engines": {
@@ -194,21 +194,21 @@
       }
     },
     "node_modules/@commitlint/execute-rule": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-14.0.0.tgz",
-      "integrity": "sha512-Hh/HLpCBDlrD3Rx2x2pDBx6CU+OtVqGXh7mbFpNihAVx6B0zyZqm/vv0cdwdhfGW5OEn1BhCqHf1ZOvL/DwdWA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-15.0.0.tgz",
+      "integrity": "sha512-pyE4ApxjbWhb1TXz5vRiGwI2ssdMMgZbaaheZq1/7WC0xRnqnIhE1yUC1D2q20qPtvkZPstTYvMiRVtF+DvjUg==",
       "dev": true,
       "engines": {
         "node": ">=v12"
       }
     },
     "node_modules/@commitlint/format": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-14.1.0.tgz",
-      "integrity": "sha512-sF6engqqHjvxGctWRKjFs/HQeNowlpbVmmoP481b2UMQnVQnjjfXJvQsoLpaqFUvgc2sHM4L85F8BmAw+iHG1w==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-15.0.0.tgz",
+      "integrity": "sha512-bPhAfqwRhPk92WiuY0ktEJNpRRHSCd+Eg1MdhGyL9Bl3U25E5zvuInA+dNctnzZiOBSH/37ZaD0eOKCpQE6acg==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/types": "^15.0.0",
         "chalk": "^4.0.0"
       },
       "engines": {
@@ -216,12 +216,12 @@
       }
     },
     "node_modules/@commitlint/is-ignored": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-14.0.0.tgz",
-      "integrity": "sha512-nJltYjXTa+mk+6SPe35nOZCCvt3Gh5mbDz008KQ4OPcn1GX1NG+pEgz1Kx3agDp/pc+JGnsrr5GV00gygIoloA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-15.0.0.tgz",
+      "integrity": "sha512-edtnkf2QZ/7e/YCJDgn1WDw9wfF1WfOitW5YEoSOb4SxjJEb/oE87kxNPZ2j8mnDMuunspcMfGHeg6fRlwaEWg==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/types": "^15.0.0",
         "semver": "7.3.5"
       },
       "engines": {
@@ -229,29 +229,29 @@
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-14.1.0.tgz",
-      "integrity": "sha512-CApGJEOtWU/CcuPD8HkOR1jdUYpjKutGPaeby9nSFzJhwl/UQOjxc4Nd+2g2ygsMi5l3N4j2sWQYEgccpFC3lA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-15.0.0.tgz",
+      "integrity": "sha512-hUi2+Im/2dJ5FBvWnodypTkg+5haCgsDzB0fyMApWLUA1IucYUAqRCQCW5em1Mhk9Crw1pd5YzFNikhIclkqCw==",
       "dev": true,
       "dependencies": {
-        "@commitlint/is-ignored": "^14.0.0",
-        "@commitlint/parse": "^14.0.0",
-        "@commitlint/rules": "^14.1.0",
-        "@commitlint/types": "^14.0.0"
+        "@commitlint/is-ignored": "^15.0.0",
+        "@commitlint/parse": "^15.0.0",
+        "@commitlint/rules": "^15.0.0",
+        "@commitlint/types": "^15.0.0"
       },
       "engines": {
         "node": ">=v12"
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-14.1.0.tgz",
-      "integrity": "sha512-p+HbgjhkqLsnxyjOUdEYHztHCp8n2oLVUJTmRPuP5FXLNevh6Gwmxf+NYC2J0sgD084aV2CFi3qu1W4yHWIknA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-15.0.0.tgz",
+      "integrity": "sha512-Ak1YPeOhvxmY3ioe0o6m1yLGvUAYb4BdfGgShU8jiTCmU3Mnmms0Xh/kfQz8AybhezCC3AmVTyBLaBZxOHR8kg==",
       "dev": true,
       "dependencies": {
-        "@commitlint/execute-rule": "^14.0.0",
-        "@commitlint/resolve-extends": "^14.1.0",
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/execute-rule": "^15.0.0",
+        "@commitlint/resolve-extends": "^15.0.0",
+        "@commitlint/types": "^15.0.0",
         "@endemolshinegroup/cosmiconfig-typescript-loader": "^3.0.2",
         "chalk": "^4.0.0",
         "cosmiconfig": "^7.0.0",
@@ -264,21 +264,21 @@
       }
     },
     "node_modules/@commitlint/message": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-14.0.0.tgz",
-      "integrity": "sha512-316Pum+bwDcZamOQw0DXSY17Dq9EjvL1zKdYIZqneu4lnXN6uFfi53Y/sP5crW6zlLdnuTHe1MnuewXPLHfH1Q==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-15.0.0.tgz",
+      "integrity": "sha512-L8euabzboKavPuDJsdIYAY2wx97LbiGEYsckMo6NmV8pOun50c8hQx6ouXFSAx4pp+mX9yUGmMiVqfrk2LKDJQ==",
       "dev": true,
       "engines": {
         "node": ">=v12"
       }
     },
     "node_modules/@commitlint/parse": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-14.0.0.tgz",
-      "integrity": "sha512-49qkk0TcwdxJPZUX8MElEzMlRFIL/cg64P4pk8HotFEm2HYdbxxZp6v3cbVw5WOsnRA0frrs+NNoOcIT83ccMQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-15.0.0.tgz",
+      "integrity": "sha512-7fweM67tZfBNS7zw1KTuuT5K2u9nGytUJqFqT/1Ln3Na9cBCsoAqR47mfsNOTlRCgGwakm4xiQ7BpS2gN0OGuw==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/types": "^15.0.0",
         "conventional-changelog-angular": "^5.0.11",
         "conventional-commits-parser": "^3.2.2"
       },
@@ -287,13 +287,13 @@
       }
     },
     "node_modules/@commitlint/read": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-14.0.0.tgz",
-      "integrity": "sha512-WXXcSLBqwXTqnEmB0lbU2TrayDJ2G3qI/lxy1ianVmpQol8p9BjodAA6bYxtYYHdQFVXUrIsclzFP/naWG+hlQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-15.0.0.tgz",
+      "integrity": "sha512-5yI1o2HKZFVe7RTjL7IhuhHMKar/MDNY34vEHqqz9gMI7BK/rdP8uVb4Di1efl2V0UPnwID0nPKWESjQ8Ti0gw==",
       "dev": true,
       "dependencies": {
-        "@commitlint/top-level": "^14.0.0",
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/top-level": "^15.0.0",
+        "@commitlint/types": "^15.0.0",
         "fs-extra": "^10.0.0",
         "git-raw-commits": "^2.0.0"
       },
@@ -302,9 +302,9 @@
       }
     },
     "node_modules/@commitlint/resolve-extends": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-14.1.0.tgz",
-      "integrity": "sha512-ko80k6QB6E6/OvGNWy4u7gzzWyluDT3VDNL2kfZaDywsnrYntUKyT4Do97gQ7orttITzj2GRtk3KWClVz4rUUQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-15.0.0.tgz",
+      "integrity": "sha512-7apfRJjgJsKja7lHsPfEFixKjA/fk/UeD3owkOw1174yYu4u8xBDLSeU3IinGPdMuF9m245eX8wo7vLUy+EBSg==",
       "dev": true,
       "dependencies": {
         "import-fresh": "^3.0.0",
@@ -317,15 +317,15 @@
       }
     },
     "node_modules/@commitlint/rules": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-14.1.0.tgz",
-      "integrity": "sha512-6jmv414/1JzGzDI/DS+snAMhcL6roQKPdg0WB3kWTWN52EvWXBFm0HIMGt2H/FlRKxozwVXlQN60/1fNIl98xA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-15.0.0.tgz",
+      "integrity": "sha512-SqXfp6QUlwBS+0IZm4FEA/NmmAwcFQIkG3B05BtemOVWXQdZ8j1vV6hDwvA9oMPCmUSrrGpHOtZK7HaHhng2yA==",
       "dev": true,
       "dependencies": {
-        "@commitlint/ensure": "^14.1.0",
-        "@commitlint/message": "^14.0.0",
-        "@commitlint/to-lines": "^14.0.0",
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/ensure": "^15.0.0",
+        "@commitlint/message": "^15.0.0",
+        "@commitlint/to-lines": "^15.0.0",
+        "@commitlint/types": "^15.0.0",
         "execa": "^5.0.0"
       },
       "engines": {
@@ -333,18 +333,18 @@
       }
     },
     "node_modules/@commitlint/to-lines": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-14.0.0.tgz",
-      "integrity": "sha512-uIXk54oJDuYyLpI208s3+cGmJ323yvSJ9LB7yUDMWUeJi2LgRxE2EBZL995kLQdnoAsBBXcLq+VDyppg5bV/cg==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-15.0.0.tgz",
+      "integrity": "sha512-mY3MNA9ujPqVpiJjTYG9MDsYCobue5PJFO0MfcIzS1mCVvngH8ZFTPAh1fT5t+t1h876boS88+9WgqjRvbYItw==",
       "dev": true,
       "engines": {
         "node": ">=v12"
       }
     },
     "node_modules/@commitlint/top-level": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-14.0.0.tgz",
-      "integrity": "sha512-MZDKZfWfl9g4KozgWBGTCrI2cXkMHnBFlhwvEfrAu5G8wd5aL1f2uWEUMnBMjUikmhVj99i1pzge4XFWHQ29wQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-15.0.0.tgz",
+      "integrity": "sha512-7Gz3t7xcuuUw1d1Nou6YLaztzp2Em+qZ6YdCzrqYc+aquca3Vt0O696nuiBDU/oE+tls4Hx2CNpAbWhTgEwB5A==",
       "dev": true,
       "dependencies": {
         "find-up": "^5.0.0"
@@ -354,9 +354,9 @@
       }
     },
     "node_modules/@commitlint/types": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-14.0.0.tgz",
-      "integrity": "sha512-sIls1nP2uSbGL466edYlh8mn7O/WP4i3bcvP+2DMhkscRCSgaPhNRWDilhYVsHt2Vu1HTQ27uT0Bj5/Lt2+EcQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-15.0.0.tgz",
+      "integrity": "sha512-OMSLX+QJnyNoTwws54ULv9sOvuw9GdVezln76oyUd4YbMMJyaav62aSXDuCdWyL2sm9hTkSzyEi52PNaIj/vqw==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0"
@@ -7846,9 +7846,9 @@
       "integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA=="
     },
     "node_modules/signal-exit": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
-      "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
+      "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
       "dev": true
     },
     "node_modules/slash": {
@@ -8004,9 +8004,9 @@
       }
     },
     "node_modules/source-map-support": {
-      "version": "0.5.20",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
-      "integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -9487,16 +9487,16 @@
       }
     },
     "@commitlint/cli": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-14.1.0.tgz",
-      "integrity": "sha512-Orq62jkl9qAGvjFqhehtAqjGY/duJ8hIRPPIHmGR2jIB96D4VTmazS3ZvqJz2Q9kKr61mLAk/171zm0FVzQCYA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-15.0.0.tgz",
+      "integrity": "sha512-Y5xmDCweytqzo4N4lOI2YRiuX35xTjcs8n5hUceBH8eyK0YbwtgWX50BJOH2XbkwEmII9blNhlBog6AdQsqicg==",
       "dev": true,
       "requires": {
-        "@commitlint/format": "^14.1.0",
-        "@commitlint/lint": "^14.1.0",
-        "@commitlint/load": "^14.1.0",
-        "@commitlint/read": "^14.0.0",
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/format": "^15.0.0",
+        "@commitlint/lint": "^15.0.0",
+        "@commitlint/load": "^15.0.0",
+        "@commitlint/read": "^15.0.0",
+        "@commitlint/types": "^15.0.0",
         "lodash": "^4.17.19",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0",
@@ -9513,62 +9513,62 @@
       }
     },
     "@commitlint/ensure": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-14.1.0.tgz",
-      "integrity": "sha512-xrYvFdqVepT3XA1BmSh88eKbvYKtLuQu98QLfgxVmwS99Kj3yW0sT3D7jGvNsynbIx2dhbXofDyubf/DKkpFrQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-15.0.0.tgz",
+      "integrity": "sha512-7DV4iNIald3vycwaWBNGk5FbonaNzOlU8nBe5m5AgU2dIeNKuXwLm+zzJzG27j0Ho56rgz//3F6RIvmsoxY9ZA==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/types": "^15.0.0",
         "lodash": "^4.17.19"
       }
     },
     "@commitlint/execute-rule": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-14.0.0.tgz",
-      "integrity": "sha512-Hh/HLpCBDlrD3Rx2x2pDBx6CU+OtVqGXh7mbFpNihAVx6B0zyZqm/vv0cdwdhfGW5OEn1BhCqHf1ZOvL/DwdWA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-15.0.0.tgz",
+      "integrity": "sha512-pyE4ApxjbWhb1TXz5vRiGwI2ssdMMgZbaaheZq1/7WC0xRnqnIhE1yUC1D2q20qPtvkZPstTYvMiRVtF+DvjUg==",
       "dev": true
     },
     "@commitlint/format": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-14.1.0.tgz",
-      "integrity": "sha512-sF6engqqHjvxGctWRKjFs/HQeNowlpbVmmoP481b2UMQnVQnjjfXJvQsoLpaqFUvgc2sHM4L85F8BmAw+iHG1w==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-15.0.0.tgz",
+      "integrity": "sha512-bPhAfqwRhPk92WiuY0ktEJNpRRHSCd+Eg1MdhGyL9Bl3U25E5zvuInA+dNctnzZiOBSH/37ZaD0eOKCpQE6acg==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/types": "^15.0.0",
         "chalk": "^4.0.0"
       }
     },
     "@commitlint/is-ignored": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-14.0.0.tgz",
-      "integrity": "sha512-nJltYjXTa+mk+6SPe35nOZCCvt3Gh5mbDz008KQ4OPcn1GX1NG+pEgz1Kx3agDp/pc+JGnsrr5GV00gygIoloA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-15.0.0.tgz",
+      "integrity": "sha512-edtnkf2QZ/7e/YCJDgn1WDw9wfF1WfOitW5YEoSOb4SxjJEb/oE87kxNPZ2j8mnDMuunspcMfGHeg6fRlwaEWg==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/types": "^15.0.0",
         "semver": "7.3.5"
       }
     },
     "@commitlint/lint": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-14.1.0.tgz",
-      "integrity": "sha512-CApGJEOtWU/CcuPD8HkOR1jdUYpjKutGPaeby9nSFzJhwl/UQOjxc4Nd+2g2ygsMi5l3N4j2sWQYEgccpFC3lA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-15.0.0.tgz",
+      "integrity": "sha512-hUi2+Im/2dJ5FBvWnodypTkg+5haCgsDzB0fyMApWLUA1IucYUAqRCQCW5em1Mhk9Crw1pd5YzFNikhIclkqCw==",
       "dev": true,
       "requires": {
-        "@commitlint/is-ignored": "^14.0.0",
-        "@commitlint/parse": "^14.0.0",
-        "@commitlint/rules": "^14.1.0",
-        "@commitlint/types": "^14.0.0"
+        "@commitlint/is-ignored": "^15.0.0",
+        "@commitlint/parse": "^15.0.0",
+        "@commitlint/rules": "^15.0.0",
+        "@commitlint/types": "^15.0.0"
       }
     },
     "@commitlint/load": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-14.1.0.tgz",
-      "integrity": "sha512-p+HbgjhkqLsnxyjOUdEYHztHCp8n2oLVUJTmRPuP5FXLNevh6Gwmxf+NYC2J0sgD084aV2CFi3qu1W4yHWIknA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-15.0.0.tgz",
+      "integrity": "sha512-Ak1YPeOhvxmY3ioe0o6m1yLGvUAYb4BdfGgShU8jiTCmU3Mnmms0Xh/kfQz8AybhezCC3AmVTyBLaBZxOHR8kg==",
       "dev": true,
       "requires": {
-        "@commitlint/execute-rule": "^14.0.0",
-        "@commitlint/resolve-extends": "^14.1.0",
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/execute-rule": "^15.0.0",
+        "@commitlint/resolve-extends": "^15.0.0",
+        "@commitlint/types": "^15.0.0",
         "@endemolshinegroup/cosmiconfig-typescript-loader": "^3.0.2",
         "chalk": "^4.0.0",
         "cosmiconfig": "^7.0.0",
@@ -9578,38 +9578,38 @@
       }
     },
     "@commitlint/message": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-14.0.0.tgz",
-      "integrity": "sha512-316Pum+bwDcZamOQw0DXSY17Dq9EjvL1zKdYIZqneu4lnXN6uFfi53Y/sP5crW6zlLdnuTHe1MnuewXPLHfH1Q==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-15.0.0.tgz",
+      "integrity": "sha512-L8euabzboKavPuDJsdIYAY2wx97LbiGEYsckMo6NmV8pOun50c8hQx6ouXFSAx4pp+mX9yUGmMiVqfrk2LKDJQ==",
       "dev": true
     },
     "@commitlint/parse": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-14.0.0.tgz",
-      "integrity": "sha512-49qkk0TcwdxJPZUX8MElEzMlRFIL/cg64P4pk8HotFEm2HYdbxxZp6v3cbVw5WOsnRA0frrs+NNoOcIT83ccMQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-15.0.0.tgz",
+      "integrity": "sha512-7fweM67tZfBNS7zw1KTuuT5K2u9nGytUJqFqT/1Ln3Na9cBCsoAqR47mfsNOTlRCgGwakm4xiQ7BpS2gN0OGuw==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/types": "^15.0.0",
         "conventional-changelog-angular": "^5.0.11",
         "conventional-commits-parser": "^3.2.2"
       }
     },
     "@commitlint/read": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-14.0.0.tgz",
-      "integrity": "sha512-WXXcSLBqwXTqnEmB0lbU2TrayDJ2G3qI/lxy1ianVmpQol8p9BjodAA6bYxtYYHdQFVXUrIsclzFP/naWG+hlQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-15.0.0.tgz",
+      "integrity": "sha512-5yI1o2HKZFVe7RTjL7IhuhHMKar/MDNY34vEHqqz9gMI7BK/rdP8uVb4Di1efl2V0UPnwID0nPKWESjQ8Ti0gw==",
       "dev": true,
       "requires": {
-        "@commitlint/top-level": "^14.0.0",
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/top-level": "^15.0.0",
+        "@commitlint/types": "^15.0.0",
         "fs-extra": "^10.0.0",
         "git-raw-commits": "^2.0.0"
       }
     },
     "@commitlint/resolve-extends": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-14.1.0.tgz",
-      "integrity": "sha512-ko80k6QB6E6/OvGNWy4u7gzzWyluDT3VDNL2kfZaDywsnrYntUKyT4Do97gQ7orttITzj2GRtk3KWClVz4rUUQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-15.0.0.tgz",
+      "integrity": "sha512-7apfRJjgJsKja7lHsPfEFixKjA/fk/UeD3owkOw1174yYu4u8xBDLSeU3IinGPdMuF9m245eX8wo7vLUy+EBSg==",
       "dev": true,
       "requires": {
         "import-fresh": "^3.0.0",
@@ -9619,37 +9619,37 @@
       }
     },
     "@commitlint/rules": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-14.1.0.tgz",
-      "integrity": "sha512-6jmv414/1JzGzDI/DS+snAMhcL6roQKPdg0WB3kWTWN52EvWXBFm0HIMGt2H/FlRKxozwVXlQN60/1fNIl98xA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-15.0.0.tgz",
+      "integrity": "sha512-SqXfp6QUlwBS+0IZm4FEA/NmmAwcFQIkG3B05BtemOVWXQdZ8j1vV6hDwvA9oMPCmUSrrGpHOtZK7HaHhng2yA==",
       "dev": true,
       "requires": {
-        "@commitlint/ensure": "^14.1.0",
-        "@commitlint/message": "^14.0.0",
-        "@commitlint/to-lines": "^14.0.0",
-        "@commitlint/types": "^14.0.0",
+        "@commitlint/ensure": "^15.0.0",
+        "@commitlint/message": "^15.0.0",
+        "@commitlint/to-lines": "^15.0.0",
+        "@commitlint/types": "^15.0.0",
         "execa": "^5.0.0"
       }
     },
     "@commitlint/to-lines": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-14.0.0.tgz",
-      "integrity": "sha512-uIXk54oJDuYyLpI208s3+cGmJ323yvSJ9LB7yUDMWUeJi2LgRxE2EBZL995kLQdnoAsBBXcLq+VDyppg5bV/cg==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-15.0.0.tgz",
+      "integrity": "sha512-mY3MNA9ujPqVpiJjTYG9MDsYCobue5PJFO0MfcIzS1mCVvngH8ZFTPAh1fT5t+t1h876boS88+9WgqjRvbYItw==",
       "dev": true
     },
     "@commitlint/top-level": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-14.0.0.tgz",
-      "integrity": "sha512-MZDKZfWfl9g4KozgWBGTCrI2cXkMHnBFlhwvEfrAu5G8wd5aL1f2uWEUMnBMjUikmhVj99i1pzge4XFWHQ29wQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-15.0.0.tgz",
+      "integrity": "sha512-7Gz3t7xcuuUw1d1Nou6YLaztzp2Em+qZ6YdCzrqYc+aquca3Vt0O696nuiBDU/oE+tls4Hx2CNpAbWhTgEwB5A==",
       "dev": true,
       "requires": {
         "find-up": "^5.0.0"
       }
     },
     "@commitlint/types": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-14.0.0.tgz",
-      "integrity": "sha512-sIls1nP2uSbGL466edYlh8mn7O/WP4i3bcvP+2DMhkscRCSgaPhNRWDilhYVsHt2Vu1HTQ27uT0Bj5/Lt2+EcQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-15.0.0.tgz",
+      "integrity": "sha512-OMSLX+QJnyNoTwws54ULv9sOvuw9GdVezln76oyUd4YbMMJyaav62aSXDuCdWyL2sm9hTkSzyEi52PNaIj/vqw==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0"
@@ -15602,9 +15602,9 @@
       "integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA=="
     },
     "signal-exit": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
-      "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
+      "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
       "dev": true
     },
     "slash": {
@@ -15731,9 +15731,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.20",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
-      "integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "gulp-string-replace": "^1.1.2",
         "husky": "^7.0.4",
         "merge-stream": "^2.0.0",
-        "prettier": "^2.4.1",
+        "prettier": "^2.5.0",
         "standard-version": "^9.3.1",
         "typedoc": "^0.22.10",
         "typescript": "^4.5.2"
@@ -6797,9 +6797,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
-      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.0.tgz",
+      "integrity": "sha512-FM/zAKgWTxj40rH03VxzIPdXmj39SwSjwG0heUcNFwI+EMZJnY93yAiKXM3dObIKAM5TA88werc8T/EwhB45eg==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -14773,9 +14773,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
-      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.0.tgz",
+      "integrity": "sha512-FM/zAKgWTxj40rH03VxzIPdXmj39SwSjwG0heUcNFwI+EMZJnY93yAiKXM3dObIKAM5TA88werc8T/EwhB45eg==",
       "dev": true
     },
     "pretty-hrtime": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "prettier": "^2.4.1",
         "standard-version": "^9.3.1",
         "typedoc": "^0.22.7",
-        "typescript": "^4.4.4"
+        "typescript": "^4.5.2"
       },
       "engines": {
         "node": ">=16.13"
@@ -8897,9 +8897,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
+      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -16449,9 +16449,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
+      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "prettier": "^2.4.1",
     "standard-version": "^9.3.1",
     "typedoc": "^0.22.7",
-    "typescript": "^4.4.4"
+    "typescript": "^4.5.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "merge-stream": "^2.0.0",
     "prettier": "^2.4.1",
     "standard-version": "^9.3.1",
-    "typedoc": "^0.22.7",
+    "typedoc": "^0.22.10",
     "typescript": "^4.5.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "reflect-metadata": "^0.1.10"
   },
   "devDependencies": {
-    "@commitlint/cli": "14.1",
+    "@commitlint/cli": "15.0",
     "@commitlint/config-conventional": "15.0",
     "@types/amqplib": "^0.8.2",
     "@types/body-parser": "^1.16.7",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@commitlint/cli": "14.1",
-    "@commitlint/config-conventional": "14.1",
+    "@commitlint/config-conventional": "15.0",
     "@types/amqplib": "^0.8.2",
     "@types/body-parser": "^1.16.7",
     "@types/cors": "^2.8.3",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "gulp-string-replace": "^1.1.2",
     "husky": "^7.0.4",
     "merge-stream": "^2.0.0",
-    "prettier": "^2.4.1",
+    "prettier": "^2.5.0",
     "standard-version": "^9.3.1",
     "typedoc": "^0.22.10",
     "typescript": "^4.5.2"


### PR DESCRIPTION
Upgrade dependencies made by dependabot

* Chore(deps-dev): Bump typescript from 4.4.4 to 4.5.2 (#85)

Bumps [typescript](https://github.com/Microsoft/TypeScript) from 4.4.4 to 4.5.2.
- [Release notes](https://github.com/Microsoft/TypeScript/releases)
- [Commits](https://github.com/Microsoft/TypeScript/compare/v4.4.4...v4.5.2)

---
updated-dependencies:
- dependency-name: typescript
  dependency-type: direct:development
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* Chore(deps-dev): Bump typedoc from 0.22.7 to 0.22.10 (#88)

Bumps [typedoc](https://github.com/TypeStrong/TypeDoc) from 0.22.7 to 0.22.10.
- [Release notes](https://github.com/TypeStrong/TypeDoc/releases)
- [Changelog](https://github.com/TypeStrong/typedoc/blob/master/CHANGELOG.md)
- [Commits](https://github.com/TypeStrong/TypeDoc/compare/v0.22.7...v0.22.10)

---
updated-dependencies:
- dependency-name: typedoc
  dependency-type: direct:development
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* Chore(deps-dev): Bump @commitlint/config-conventional (#89)

Bumps [@commitlint/config-conventional](https://github.com/conventional-changelog/commitlint/tree/HEAD/@commitlint/config-conventional) from 14.1.0 to 15.0.0.
- [Release notes](https://github.com/conventional-changelog/commitlint/releases)
- [Changelog](https://github.com/conventional-changelog/commitlint/blob/master/@commitlint/config-conventional/CHANGELOG.md)
- [Commits](https://github.com/conventional-changelog/commitlint/commits/v15.0.0/@commitlint/config-conventional)

---
updated-dependencies:
- dependency-name: "@commitlint/config-conventional"
  dependency-type: direct:development
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* Chore(deps-dev): Bump prettier from 2.4.1 to 2.5.0 (#87)

Bumps [prettier](https://github.com/prettier/prettier) from 2.4.1 to 2.5.0.
- [Release notes](https://github.com/prettier/prettier/releases)
- [Changelog](https://github.com/prettier/prettier/blob/main/CHANGELOG.md)
- [Commits](https://github.com/prettier/prettier/compare/2.4.1...2.5.0)

---
updated-dependencies:
- dependency-name: prettier
  dependency-type: direct:development
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* Chore(deps-dev): Bump @commitlint/cli from 14.1.0 to 15.0.0 (#86)

Bumps [@commitlint/cli](https://github.com/conventional-changelog/commitlint/tree/HEAD/@commitlint/cli) from 14.1.0 to 15.0.0.
- [Release notes](https://github.com/conventional-changelog/commitlint/releases)
- [Changelog](https://github.com/conventional-changelog/commitlint/blob/master/@commitlint/cli/CHANGELOG.md)
- [Commits](https://github.com/conventional-changelog/commitlint/commits/v15.0.0/@commitlint/cli)

---
updated-dependencies:
- dependency-name: "@commitlint/cli"
  dependency-type: direct:development
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>